### PR TITLE
Update common.graphqls

### DIFF
--- a/common.graphqls
+++ b/common.graphqls
@@ -92,7 +92,7 @@ enum Scope {
     ENDPOINT_RELATION
 }
 
-enum CallDetectPoint {
+enum DetectPoint {
     CLIENT
     SERVER
     PROXY


### PR DESCRIPTION
Type name mistake when rename the parameter in call type.

@wu-sheng @hanahmily 